### PR TITLE
Force grouped output with line numbers

### DIFF
--- a/gk-roam.el
+++ b/gk-roam.el
@@ -107,7 +107,7 @@
   ;; (gk-roam-delete-reference file)
   (let* ((name (generate-new-buffer-name (format " *%s*" process)))
          (process (start-process
-                   name name "rg" "-F" ;; 排除临时文件和index.org等
+                   name name "rg" "-Fn" "--heading"
 		   (gk-roam--format-link file)
 		   (expand-file-name (file-name-directory file)) ;; must be absolute path.
 		   "-g" "!index.org*"))


### PR DESCRIPTION
Fixes a bug in which the ripgrep output format differs on different platforms, depending on whether Emacs spawns processes in a shell or not. The `--heading` flag forces one filename heading for each matching file followed by individual matches (which is what macOS is producing without the flag), and the `-n` flag forces line numbers to be displayed at the beginning of each match line.

This should force `ripgrep` output to be identical regardless of shell and platform settings so that the parsing code works.

I removed the inline comment because I believe it applies to a different line, and I considered it to be redundant unless we wanted to comment all of the `ripgrep` flags. If you'd like, I can add that to this patch.

I tested this change in Windows and macOS and both are working.