### PR TITLE
Fix issue #30, gkroam-file-re misunderstands `gkroam-file-re`

### DIFF
--- a/gkroam.el
+++ b/gkroam.el
@@ -444,7 +444,7 @@ The backlink refers to a link in LINE-NUMBER line of PAGE."
       (insert string)
       (goto-char (point-min))
       (let ((gkroam-file-re
-             (concat "^" (expand-file-name ".+\\.org" gkroam-root-dir)))
+             (concat "^" (expand-file-name gkroam-root-dir) ".+\\.org"))
             (beg (point-min)) (end (point)) (num 0) references)
         (while (not (= end (point-max)))
           (save-excursion


### PR DESCRIPTION
* gkroam.el (gkroam--process-searched-string): Fix path and regexp so it
	works also in Windows.