### PR TITLE
fix #33: don't use custom gkroam-link-with-headline-re, use default

### DIFF
--- a/gkroam.el
+++ b/gkroam.el
@@ -211,9 +211,6 @@ The default format is '%Y%m%d%H%M%S' time string."
            (group "]}")))
   "Regular expression that matches a gkroam hashtag.")
 
-(defvar gkroam-link-with-headline-re "{\\[\\(.+?\\) » \\(.+?\\)\\].*}"
-  "Gkroam headline link regexp.")
-
 (defvar gkroam-reference-delimiter-re
   "^* \\([0-9]+\\) Linked References.*"
   "Delimiter string regexp to separate page contents from references region.")
@@ -788,10 +785,11 @@ to a \"%Y-%m-%d %H-%M-%S\" time string."
   "Cache current page's gkroam headline links."
   (save-excursion
     (goto-char (point-min))
-    (while (re-search-forward gkroam-link-with-headline-re nil t)
-      (gkroam-set-headline-id
-       (match-string-no-properties 1)
-       (match-string-no-properties 2)))))
+    (while (re-search-forward gkroam-link-regexp nil t)
+      (when (gkroam--link-has-headline)
+        (gkroam-set-headline-id
+         (match-string-no-properties 2)
+         (match-string-no-properties 5))))))
 
 (defun gkroam-search-all-headline-links ()
   "Return a rg process to search all gkroam headline links.


### PR DESCRIPTION
* gkroam.el (gkroam-link-with-headline-re): remove variable, it
  matches links incorrectly if there are links without headlines on the
  same line and it's not really needed since `gkroam-link-regexp'
  fills the same purpose (and more).

  (gkroam-cache-curr-headline-links): Remove use of
  `gkroam-link-with-headline-re' in favor for `gkroam-link-regexp'