### PR TITLE
Make sure rg doesn't match on more than it should

### DIFF
--- a/gkroam.el
+++ b/gkroam.el
@@ -563,7 +563,7 @@ If type is 'unlinked', it means to process unlinked references."
   "Return a rg process to search a specific TITLE page's link.
 Output matched files' path and context."
   (gkroam-start-process " *gkroam-rg*"
-                        `(,(format "\\{\\[%s.*?\\](\\[.+?\\])?\\}" title)
+                        `(,(format "\\{\\[%s( ».*)?\\](\\[.+?\\])?\\}" title)
                           "--ignore-case" "--sortr" "path"
                           "-C" ,(number-to-string 9999)
                           "-N" "--heading"


### PR DESCRIPTION
* gkroam.el (gkroam-search-page-link): Make sure the page link search
matches on the whole page, not on the title as a prefix for the whole
page name.