### PR TITLE
Set margins only when prettify is enabled and margins are set

### DIFF
--- a/gkroam.el
+++ b/gkroam.el
@@ -1890,11 +1890,11 @@ With optional argument ALIAS, format also with alias."
 
 (defun gkroam-set-window-margin ()
   "Set gkroam pages' window margin."
-  (if gkroam-prettify-page-p
+  (if (and gkroam-prettify-page-p
+           gkroam-window-margin)
       (set-window-margins (selected-window)
                           gkroam-window-margin
-                          gkroam-window-margin)
-    (set-window-margins (selected-window) 0 0)))
+                          gkroam-window-margin)))
 
 (defun gkroam-preserve-window-margin ()
   "Preserve gkroam pages' window margin."
@@ -2080,7 +2080,7 @@ With optional argument ALIAS, format also with alias."
     (when (or (gkroam-at-linked-buf)
               (gkroam-at-unlinked-buf))
       (gkroam-mentions-mode -1))
-    (set-window-margins (selected-window) 0 0)
+    (gkroam-preserve-window-margin)
     (with-silent-modifications
       (set-text-properties (point-min) (point-max) nil))))
 


### PR DESCRIPTION
This is related to #46 and solves that specific issue for me, but I submit this only a demonstration. There may be other use cases that I am not thinking of, in which case I'll be happy to work together to amend this solution.

The goals of this patch are:

1. Preserve the behavior of "prettify" when margins are set to a non-nil value.
2. Never reset window margins in any other case (preserving user-set values, such as the right margin configured by `visual-fill-column-mode`).

For my use case, I configure `gkroam-prettify-page-p` to `t` and also set `gkroam-window-margins` to `nil` in my package initialization, which allows `visual-fill-column-mode` to behave as expected. If, instead, `gkroam-window-margins` is set to its default of `2` or any other value, that margin setting will take effect in all gkroam windows.