### PR TITLE
Read possible 'alias' value naively instead of using completion

### DIFF
--- a/gkroam.el
+++ b/gkroam.el
@@ -1209,9 +1209,8 @@ If WITHOUT-HEADLINE is non-nil, don't format headline in link."
                           "Choose a headline or press \"C-p RET\" (\"RET\") to skip: "
                           headlines-exist-p nil nil)))
              (alias (or alias
-                        (completing-read
-                         "Give an alias or press \"RET\" to skip: "
-                         nil nil nil))))
+                        (read-string
+                         "Give an alias or press \"RET\" to skip: "))))
         (when (string= headline "") (setq headline nil))
         (when (string= alias "") (setq alias nil))
         (when headline


### PR DESCRIPTION
This patch addresses #48 by calling `read-string` to ask the user for an "alias" value, instead of calling `completing-read` with no collection from which to complete.

The user experience is identical; if a string is provided, it will be used as the alias. If no string is provided, the empty string is substituted by `nil` on line 1215 and the linked page's title is used.