### PR TITLE
Allow a nil window margin in customize

### DIFF
--- a/gkroam.el
+++ b/gkroam.el
@@ -150,8 +150,9 @@
   :group 'gkroam)
 
 (defcustom gkroam-window-margin 2
-  "Gkroam window's left and right margin."
-  :type 'integer
+  "Gkroam window's left and right margin, or nil to ignore margin settings."
+  :type '(choice (integer :tag "Number of spaces")
+                 (const :tag "Ignore margin settings" nil))
   :group 'gkroam)
 
 (defcustom gkroam-use-default-filename nil


### PR DESCRIPTION
Previous change aeb502ce20d2cb11bba78581860496b618d254ab allowed `nil` for the window margin value, which would cause gkroam to ignore window margin settings entirely. This patch changes the customize configuration so that a `nil` value can be selected by the user in the customize facility, and an externally configured `nil` value will appear correctly in the customize interface.